### PR TITLE
Initialize ControlSetup during construction

### DIFF
--- a/free_gait_core/src/base_motion/BaseTrajectory.cpp
+++ b/free_gait_core/src/base_motion/BaseTrajectory.cpp
@@ -13,7 +13,9 @@ namespace free_gait {
 BaseTrajectory::BaseTrajectory()
     : BaseMotionBase(BaseMotionBase::Type::Trajectory),
       duration_(0.0),
-      isComputed_(false)
+      isComputed_(false),
+      controlSetup_ { {ControlLevel::Position, false}, {ControlLevel::Velocity, false},
+                            {ControlLevel::Acceleration, false}, {ControlLevel::Effort, false} }
 {
 }
 

--- a/free_gait_core/src/leg_motion/EndEffectorTarget.cpp
+++ b/free_gait_core/src/leg_motion/EndEffectorTarget.cpp
@@ -21,7 +21,9 @@ EndEffectorTarget::EndEffectorTarget(LimbEnum limb)
       averageVelocity_(0.0),
       ignoreContact_(false),
       ignoreForPoseAdaptation_(false),
-      isComputed_(false)
+      isComputed_(false),
+      controlSetup_ { {ControlLevel::Position, false}, {ControlLevel::Velocity, false},
+                            {ControlLevel::Acceleration, false}, {ControlLevel::Effort, false} }
 {
 }
 

--- a/free_gait_core/src/leg_motion/JointTrajectory.cpp
+++ b/free_gait_core/src/leg_motion/JointTrajectory.cpp
@@ -13,7 +13,9 @@ JointTrajectory::JointTrajectory(LimbEnum limb)
     : JointMotionBase(LegMotionBase::Type::JointTrajectory, limb),
       ignoreContact_(false),
       duration_(0.0),
-      isComputed_(false)
+      isComputed_(false),
+      controlSetup_ { {ControlLevel::Position, false}, {ControlLevel::Velocity, false},
+                            {ControlLevel::Acceleration, false}, {ControlLevel::Effort, false} }
 {
 }
 


### PR DESCRIPTION
This prevents out_of_range exceptions, e.g. when passing steps to the batch executor.

Maybe next, can remove corresponding lines:
`baseTrajectory.controlSetup_[ControlLevel::Position] = false;`
`baseTrajectory.controlSetup_[ControlLevel::Velocity] = false;`
`etc.`
from `fromMessage` methods?