### PR TITLE
free_gait_rviz_plugin: Skip stance display if no foot is in ground contact.

### DIFF
--- a/free_gait_rviz_plugin/src/FreeGaitPreviewVisual.cpp
+++ b/free_gait_rviz_plugin/src/FreeGaitPreviewVisual.cpp
@@ -200,6 +200,7 @@ void FreeGaitPreviewVisual::showStances(const float alpha)
   stancesMarker_.clear();
 
   for (const auto& stance : stateBatchPtr_->getStances()) {
+    if (stance.second.empty()) continue;
     std_msgs::ColorRGBA color;
     getRainbowColor(stateBatchPtr_->getStartTime(), stateBatchPtr_->getEndTime(), stance.first, color);
     color.a = alpha;


### PR DESCRIPTION
When no foot is in ground contact a stance marker was created containing no polygons. This lead to a crash of the plugin (and therefore rviz) as soon as the marker was destroyed (see gdb output). This fix prohibits the creation of an empty stance marker and solves the issue.


(gdb) 
#0  0x00007ffff69e0428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007ffff69e202a in __GI_abort () at abort.c:89
#2  0x00007ffff701a84d in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff70186b6 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff70176a9 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff7018005 in __gxx_personality_v0 () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff6d84f83 in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#7  0x00007ffff6d852eb in _Unwind_RaiseException () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#8  0x00007ffff701890c in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff3b7ea16 in Ogre::SceneManager::destroyMovableObject(Ogre::MovableObject*) ()
   from /usr/lib/x86_64-linux-gnu/libOgreMain.so.1.9.0
#10 0x00007fffa439280f in rviz::TriangleListMarker::~TriangleListMarker() () from /opt/ros/kinetic/lib/librviz_default_plugin.so
#11 0x00007fffa43928d9 in rviz::TriangleListMarker::~TriangleListMarker() () from /opt/ros/kinetic/lib/librviz_default_plugin.so
#12 0x00007fff79f6e8e6 in free_gait_rviz_plugin::FreeGaitPreviewVisual::hideStances() ()
   from /home/remod/projects/anymal/catkin_ws/devel/lib//libfree_gait_rviz_plugin.so
#13 0x00007fff79f700a0 in free_gait_rviz_plugin::FreeGaitPreviewVisual::update() ()
   from /home/remod/projects/anymal/catkin_ws/devel/lib//libfree_gait_rviz_plugin.so
#14 0x00007fff79f4802a in free_gait_rviz_plugin::FreeGaitPreviewDisplay::update(float, float) ()
   from /home/remod/projects/anymal/catkin_ws/devel/lib//libfree_gait_rviz_plugin.so
#15 0x00007ffff7a8265d in rviz::DisplayGroup::update(float, float) () from /opt/ros/kinetic/lib/librviz.so
#16 0x00007ffff7a8265d in rviz::DisplayGroup::update(float, float) () from /opt/ros/kinetic/lib/librviz.so
#17 0x00007ffff7b4c885 in rviz::VisualizationManager::onUpdate() () from /opt/ros/kinetic/lib/librviz.so
#18 0x00007ffff217bd2a in QMetaObject::activate(QObject*, int, int, void**) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#19 0x00007ffff21885c8 in QTimer::timerEvent(QTimerEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#20 0x00007ffff217cbb3 in QObject::event(QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#21 0x00007ffff746805c in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#22 0x00007ffff746d516 in QApplication::notify(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#23 0x00007ffff214d38b in QCoreApplication::notifyInternal(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#24 0x00007ffff21a25ed in QTimerInfoList::activateTimers() () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#25 0x00007ffff21a2af1 in ?? () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#26 0x00007ffff16a4197 in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#27 0x00007ffff16a43f0 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#28 0x00007ffff16a449c in g_main_context_iteration () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#29 0x00007ffff21a37eb in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
   from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#30 0x00007ffff214ab4a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#31 0x00007ffff2152bec in QCoreApplication::exec() () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#32 0x0000000000400c99 in main ()