### PR TITLE
add missing urdf/model.h header

### DIFF
--- a/free_gait_ros/src/StateRosPublisher.cpp
+++ b/free_gait_ros/src/StateRosPublisher.cpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <urdf/model.h>
+
 namespace free_gait {
 
 StateRosPublisher::StateRosPublisher(ros::NodeHandle& nodeHandle,


### PR DESCRIPTION
This was needed to compile for Ubuntu 14.04 with ros indigo.