### PR TITLE
[free_gait_core] Resetting executor at first advance, not init

### DIFF
--- a/free_gait_core/include/free_gait_core/executor/Executor.hpp
+++ b/free_gait_core/include/free_gait_core/executor/Executor.hpp
@@ -98,6 +98,7 @@ class Executor
 
   Mutex mutex_;
   bool isInitialized_;
+  bool isReset_;
   bool isPausing_;
   PreemptionType preemptionType_;
   StepQueue queue_;

--- a/free_gait_core/src/executor/Executor.cpp
+++ b/free_gait_core/src/executor/Executor.cpp
@@ -35,6 +35,7 @@ bool Executor::initialize()
 {
   computer_.initialize();
   state_.initialize(adapter_.getLimbs(), adapter_.getBranches());
+  isReset_ = false;
   return isInitialized_ = true;
 }
 

--- a/free_gait_core/src/executor/Executor.cpp
+++ b/free_gait_core/src/executor/Executor.cpp
@@ -19,6 +19,7 @@ Executor::Executor(StepCompleter& completer,
       adapter_(adapter),
       state_(state),
       isInitialized_(false),
+      isReset_(false),
       isPausing_(false),
       preemptionType_(PreemptionType::PREEMPT_STEP),
       queue_(),
@@ -34,7 +35,6 @@ bool Executor::initialize()
 {
   computer_.initialize();
   state_.initialize(adapter_.getLimbs(), adapter_.getBranches());
-  reset();
   return isInitialized_ = true;
 }
 
@@ -51,6 +51,10 @@ Executor::Mutex& Executor::getMutex()
 bool Executor::advance(double dt, bool skipStateMeasurmentUpdate)
 {
   if (!isInitialized_) return false;
+  if (!isReset_) {
+    reset();
+    isReset_ = true;
+  }
   if (!skipStateMeasurmentUpdate) updateStateWithMeasurements();
   bool executionStatus = adapter_.isExecutionOk() && !isPausing_;
 


### PR DESCRIPTION
Removes the "Unhandled joint mode" warning seen sometimes at startup.

Instead of reseting the executor in initialized (when the adapter contains default values), now it's reset a the first advance with the first measurements.