### PR TITLE
Fixes for compiler warnings.

### DIFF
--- a/free_gait_core/include/free_gait_core/executor/ExecutorState.hpp
+++ b/free_gait_core/include/free_gait_core/executor/ExecutorState.hpp
@@ -20,8 +20,8 @@ class ExecutorState
   virtual ~ExecutorState();
 
   void setState(size_t stepNumber, double stepPhase);
-  const size_t stepNumber() const;
-  const double stepPhase() const;
+  size_t stepNumber() const;
+  double stepPhase() const;
 
   friend bool operator>(const ExecutorState& stateA, const ExecutorState& stateB);
   friend bool operator<=(const ExecutorState& stateA, const ExecutorState& stateB);

--- a/free_gait_core/src/executor/ExecutorState.cpp
+++ b/free_gait_core/src/executor/ExecutorState.cpp
@@ -31,12 +31,12 @@ void ExecutorState::setState(size_t stepNumber, double stepPhase)
    stepPhase_ = stepPhase;
 }
 
-const size_t ExecutorState::stepNumber() const
+size_t ExecutorState::stepNumber() const
 {
   return stepNumber_;
 }
 
-const double ExecutorState::stepPhase() const
+double ExecutorState::stepPhase() const
 {
   return stepPhase_;
 }

--- a/free_gait_ros/include/free_gait_ros/FreeGaitActionClient.hpp
+++ b/free_gait_ros/include/free_gait_ros/FreeGaitActionClient.hpp
@@ -13,7 +13,10 @@
 #include <free_gait_msgs/ExecuteActionFeedback.h>
 
 // ROS
+#pragma GCC diagnostic push // Get rid of compiler warnings we can't fix.
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <actionlib/client/simple_action_client.h>
+#pragma GCC diagnostic pop // Back to normal warning handling.
 #include <tf2_ros/transform_listener.h>
 
 // STD


### PR DESCRIPTION
Fixed some warnings that would be triggered in downstream packages including header files from this repo when building with the '-Wall -Wextra -Wpedantic' compiler flags.