### PR TITLE
Fix: Error - Swing profile of type '' not supported

### DIFF
--- a/free_gait_core/src/leg_motion/Footstep.cpp
+++ b/free_gait_core/src/leg_motion/Footstep.cpp
@@ -17,6 +17,7 @@ namespace free_gait {
 Footstep::Footstep(LimbEnum limb)
     : EndEffectorMotionBase(LegMotionBase::Type::Footstep, limb),
       profileHeight_(0.0),
+      profileType_("triangle"),
       averageVelocity_(0.0),
       liftOffSpeed_(0.0),
       touchdownSpeed_(0.0),


### PR DESCRIPTION
Adding triangle as the default swing profile type so that footstep planner precomputations doesn't throw error when encountering empty swing profile type.